### PR TITLE
SDK version 3.5.6 - supports 16KB memory page

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -18,7 +18,7 @@ Android Studio
 #### Installation
 1. import lib in build.gradle:
 ```
-implementation 'com.ttlock:ttlock:3.5.4'
+implementation 'com.ttlock:ttlock:3.5.6'
 ```
 2. add permission in manifest:
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Android Studio
 ## 使用说明
 ### 引入SDK
 ```
-implementation 'com.ttlock:ttlock:3.5.4'
+implementation 'com.ttlock:ttlock:3.5.6'
 ```
 
 ### manifest配置

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 //    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 //    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     implementation 'com.google.code.gson:gson:2.6.2'
-    implementation 'com.ttlock:ttlock:3.5.4'
+    implementation 'com.ttlock:ttlock:3.5.6'
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
 }


### PR DESCRIPTION
Google Play is strictly requiring all apps to support 16KB page size. 

https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html

The README and gradle files still use old 3.5.4 SDK which makes developers unable to submit their apps on play store. 